### PR TITLE
Fix working directory and add major tag

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -2,7 +2,7 @@ name: Build and publish
 on:
   push:
     tags-ignore:
-      - '*.*'
+      - "*.*"
     branches:
       - main
       - develop
@@ -55,17 +55,20 @@ jobs:
           fi
 
           NEXT_VERSION="v$(npx semver "$LAST_TAG" -i $BUMP_TYPE --preid rc)"
-          
           echo "::set-output name=is-pre-release::$IS_PRE_RELEASE"
           echo "::set-output name=next-version::$NEXT_VERSION"
 
       - name: Create tag
         run: |
+          MAJOR_TAG=$(echo "${{ steps.vars.outputs.next-version }}" | sed "s/\..*//")
+
           git config --global user.email "${{ github.event.pusher.email }}"
           git config --global user.name "${{ github.event.pusher.name }}"
           git add .
           git commit -m 'release: ${{ steps.vars.outputs.next-version }}'
           git tag ${{ steps.vars.outputs.next-version }}
+          git tag $MAJOR_TAG -f -a -m "Update tag with version ${{ steps.vars.outputs.next-version }}"
+          git push origin tag $MAJOR_TAG --force
           git push origin --tags
 
       - name: Create Release
@@ -76,6 +79,6 @@ jobs:
         with:
           tag_name: ${{ steps.vars.outputs.next-version }}
           release_name: ${{ steps.vars.outputs.next-version }}
-          body: ''
+          body: ""
           draft: false
           prerelease: ${{ steps.vars.outputs.is-pre-release }}

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -55,6 +55,7 @@ jobs:
           fi
 
           NEXT_VERSION="v$(npx semver "$LAST_TAG" -i $BUMP_TYPE --preid rc)"
+
           echo "::set-output name=is-pre-release::$IS_PRE_RELEASE"
           echo "::set-output name=next-version::$NEXT_VERSION"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 on:
   push:
     tags-ignore:
-      - '*.*'
+      - "*.*"
     branches:
-      - '**'
+      - "**"
 
 jobs:
   test_on_machine:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ S3 Cache for GitHub Actions supports builds on Linux, Windows and MacOS.
 
 ```yml
 - name: Save cache
-  uses: leroy-merlin-br/action-s3-cache@v1.0.3
+  uses: leroy-merlin-br/action-s3-cache@v1
   with:
     action: put
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -34,7 +34,7 @@ S3 Cache for GitHub Actions supports builds on Linux, Windows and MacOS.
 
 ```yml
 - name: Retrieve cache
-  uses: leroy-merlin-br/action-s3-cache@v1.0.3
+  uses: leroy-merlin-br/action-s3-cache@v1
   with:
     action: get
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -48,7 +48,7 @@ S3 Cache for GitHub Actions supports builds on Linux, Windows and MacOS.
 
 ```yml
 - name: Clear cache
-  uses: leroy-merlin-br/action-s3-cache@v1.0.3
+  uses: leroy-merlin-br/action-s3-cache@v1
   with:
     action: delete
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -68,7 +68,7 @@ The following example shows a simple pipeline using S3 Cache GitHub Action:
   uses: actions/checkout@v2
 
 - name: Retrieve cache
-  uses: leroy-merlin-br/action-s3-cache@v1.0.3
+  uses: leroy-merlin-br/action-s3-cache@v1
   with:
     action: get
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -81,7 +81,7 @@ The following example shows a simple pipeline using S3 Cache GitHub Action:
   run: yarn
 
 - name: Save cache
-  uses: leroy-merlin-br/action-s3-cache@v1.0.3
+  uses: leroy-merlin-br/action-s3-cache@v1
   with:
     action: put
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/entrypoint.sh
+    - run: ${{ github.action_path }}entrypoint.sh
       shell: bash
       env:
         ACTION: ${{ inputs.action }}

--- a/action.yml
+++ b/action.yml
@@ -28,11 +28,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}entrypoint.sh
+    - run: $GITHUB_ACTION_PATH/entrypoint.sh
       shell: bash
       env:
         ACTION: ${{ inputs.action }}
-        ACTION_PATH: ${{ github.action_path }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
         AWS_REGION: ${{ inputs.aws-region }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Select right go binary for runner os
-$ACTION_PATH/dist/$(echo "$OS" | tr "[:upper:]" "[:lower:]")
+$GITHUB_ACTION_PATH/dist/$(echo "$OS" | tr "[:upper:]" "[:lower:]")


### PR DESCRIPTION
Estamos resolvendo o problema do working directory no windows, onde o arquivo `entrypoint.sh` não era encontrado por conta do valor de `${{ github.action_path }}`

Também estamos adicionando o release/update da tag de major, para facilitar releases de patch e minor.